### PR TITLE
feat: handle audio playback errors

### DIFF
--- a/frontend/src/lib/components/AudioPlayer.svelte
+++ b/frontend/src/lib/components/AudioPlayer.svelte
@@ -1,34 +1,49 @@
 <script lang="ts">
     export let audioUrl: string;
     export let title: string;
-    
+    export let onError: ((error: unknown) => void) | undefined;
+
     let audio: HTMLAudioElement;
     let playing = false;
     let currentTime = 0;
     let duration = 0;
-    
-    function togglePlay() {
+    export let playbackError: unknown = null;
+
+    async function togglePlay() {
       if (playing) {
         audio.pause();
       } else {
-        audio.play();
+        try {
+          await audio.play();
+        } catch (error) {
+          playbackError = error;
+          onError?.(error);
+        }
       }
     }
-    
+
     function updateTime() {
       currentTime = audio.currentTime;
       duration = audio.duration || 0;
     }
+
+    function handleError(event: Event) {
+      const err = (event.currentTarget as HTMLAudioElement).error;
+      playbackError = err;
+      onError?.(err);
+    }
   </script>
-  
+
   <div class="bg-livy-black text-livy-parchment p-4 rounded-lg">
-    <audio 
-      bind:this={audio} 
-      src={audioUrl} 
+    <audio
+      bind:this={audio}
+      src={audioUrl}
       on:play={() => playing = true}
       on:pause={() => playing = false}
+      on:ended={() => playing = false}
       on:timeupdate={updateTime}
       on:loadedmetadata={updateTime}
+      on:error={handleError}
     ></audio>
     
     <div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- make `togglePlay` async and handle play promise rejections
- reset playing state when audio ends
- surface playback issues via optional `onError` callback

## Testing
- `yarn test` (fails: Couldn't find a script named "test")
- `yarn lint` (fails: Cannot find package 'prettier-plugin-svelte')
- `yarn check`


------
https://chatgpt.com/codex/tasks/task_e_6896faeea050832bb25ae375d5620260