### PR TITLE
feat: improve api fetch error handling

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,20 +1,39 @@
-const API_BASE = 'http://localhost:8000/api';
+const API_BASE = import.meta.env.VITE_API_BASE as string;
+
+export async function apiFetch(
+  path: string,
+  options?: RequestInit
+): Promise<any> {
+  try {
+    const response = await fetch(`${API_BASE}${path}`, options);
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(`API request failed: ${response.status} ${response.statusText}\n${message}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    throw error;
+  }
+}
 
 export async function fetchTours() {
-  const response = await fetch(`${API_BASE}/tours`);
-  return response.json();
+  return apiFetch('/tours');
 }
 
 export async function fetchTour(slug: string) {
-  const response = await fetch(`${API_BASE}/tours/${slug}`);
-  return response.json();
+  return apiFetch(`/tours/${slug}`);
 }
 
-export async function askQuestion(tourId: string, stopId: string, question: string) {
-  const response = await fetch(`${API_BASE}/qa`, {
+export async function askQuestion(
+  tourId: string,
+  stopId: string,
+  question: string
+) {
+  return apiFetch('/qa', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ tourId, stopId, question })
   });
-  return response.json();
 }
+


### PR DESCRIPTION
## Summary
- use env variable for API base URL
- centralize fetch and error handling via apiFetch helper

## Testing
- `yarn lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `yarn check`


------
https://chatgpt.com/codex/tasks/task_e_6896fb60e0f4832b84500197cb6b3f7c