### PR TITLE
Embed maplibre stylesheet for map view

### DIFF
--- a/frontend/src/lib/components/Map.svelte
+++ b/frontend/src/lib/components/Map.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { onMount } from 'svelte';
     import maplibregl from 'maplibre-gl';
+    import 'maplibre-gl/dist/maplibre-gl.css';
     
     export let center: [number, number] = [-84.5, 38.05]; // Lexington, KY
     export let zoom: number = 14;

--- a/frontend/src/routes/map/+page.svelte
+++ b/frontend/src/routes/map/+page.svelte
@@ -4,7 +4,6 @@
   
   <svelte:head>
     <title>Map - Livy</title>
-    <link href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css" rel="stylesheet" />
   </svelte:head>
   
   <div class="space-y-6">


### PR DESCRIPTION
## Summary
- remove remote MapLibre CSS link from map page
- import MapLibre stylesheet directly in map component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6896fae344e8832bad61e87c03f3688e