### PR TITLE
Include frontend paths in Tailwind configuration

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    content: ["./src/**/*.{html,js,svelte,ts}"],
+    content: ["./src/**/*.{html,js,svelte,ts}", "./frontend/src/**/*.{html,js,svelte,ts}"],
     theme: {
       extend: {},
     },


### PR DESCRIPTION
## Summary
- include `frontend/src` in Tailwind's `content` paths so styles are generated for the frontend app

## Testing
- `yarn build`
- `yarn lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm --prefix frontend run build` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_6896fad3319c832bbb4f37275819b2c9