### PR TITLE
chore: ensure newline at EOF in layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,4 +3,3 @@
   </script>
   
   <slot />
-  


### PR DESCRIPTION
## Summary
- add missing newline at end of `src/routes/+layout.svelte`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_6897201de444832bb228fd57b1cb8240