### PR TITLE
chore: remove unused imports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,4 @@
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi import UploadFile, File
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
## Summary
- remove unused FastAPI imports

## Testing
- `ruff check backend/main.py`
- `PYTHONPATH=. pytest` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*
- `pip install python-multipart` *(fails: Could not find a version that satisfies the requirement python-multipart)*

------
https://chatgpt.com/codex/tasks/task_e_689726b814d8832bb1f3132d8f863b39