### PR TITLE
Restrict CORS origins to trusted domains

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,8 +12,8 @@ app = FastAPI(title="Livy Backend")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=["https://example.com"],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- Replace wildcard CORS origins with explicit trusted domain
- Disable credentialed cross-origin requests unless needed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_689726c3c4ec832b8192e6439f07b08e