### PR TITLE
Validate upload filenames for presigned URL route

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,3 +17,17 @@ def test_token_auth_flow():
     secure = client.get("/secure", headers={"Authorization": f"Bearer {token}"})
     assert secure.status_code == 200
     assert secure.json() == {"user": "alice"}
+
+
+def test_upload_url_valid_filename(monkeypatch):
+    monkeypatch.setattr(
+        "backend.main.get_presigned_url", lambda key: "http://example.com/upload"
+    )
+    response = client.get("/upload-url", params={"filename": "good.txt"})
+    assert response.status_code == 200
+    assert response.json()["url"] == "http://example.com/upload"
+
+
+def test_upload_url_invalid_filename():
+    response = client.get("/upload-url", params={"filename": "../bad.txt"})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add secure endpoint for authentication testing
- validate filenames for `/upload-url` and enforce extension whitelist
- test valid and invalid filename handling

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973a2a94c4832bbc231713ea6c608b