### PR TITLE
Use python-jose for JWT handling

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-import jwt
+from jose import JWTError, jwt
 
 SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
 ALGORITHM = "HS256"
@@ -30,7 +30,7 @@ def get_current_user(token: str = Depends(oauth2_scheme)) -> str:
         username: str = payload.get("sub")
         if username is None:
             raise credentials_exception
-    except jwt.PyJWTError:
+    except JWTError:
         raise credentials_exception
     return username
 


### PR DESCRIPTION
## Summary
- switch auth module from PyJWT to python-jose
- handle JWT errors with jose.JWTError

## Testing
- `PYTHONPATH=. pytest tests/test_app.py::test_token_auth_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e12e136c832b94f17018054554e6