### PR TITLE
Add response schemas and validate in tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,12 @@ from .auth import (
     get_current_user,
 )
 from .storage import get_presigned_url
+from .schemas import (
+    RootResponse,
+    SecureResponse,
+    TokenResponse,
+    UploadURLResponse,
+)
 
 app = FastAPI(title="Livy Backend")
 
@@ -40,29 +46,29 @@ def on_startup() -> None:
 
 
 @app.get("/")
-def read_root():
-    return {"status": "ok"}
+def read_root() -> RootResponse:
+    return RootResponse(status="ok")
 
 
 @app.post("/token")
-def login(form_data: OAuth2PasswordRequestForm = Depends()):
+def login(form_data: OAuth2PasswordRequestForm = Depends()) -> TokenResponse:
     """Authenticate user and issue an access token."""
     hashed_pw = sha256(form_data.password.encode()).hexdigest()
     if users_db.get(form_data.username) != hashed_pw:
         raise HTTPException(status_code=400, detail="Invalid username or password")
 
     access_token = create_access_token({"sub": form_data.username})
-    return {"access_token": access_token, "token_type": "bearer"}
+    return TokenResponse(access_token=access_token, token_type="bearer")
 
 
 @app.get("/secure")
-def secure(current_user: str = Depends(get_current_user)):
+def secure(current_user: str = Depends(get_current_user)) -> SecureResponse:
     """Protected route used for testing token authentication."""
-    return {"user": current_user}
+    return SecureResponse(user=current_user)
 
 
 @app.get("/upload-url")
-def upload_url(filename: str):
+def upload_url(filename: str) -> UploadURLResponse:
     """Return a presigned S3 URL for uploading a file.
 
     The provided ``filename`` must only contain alphanumeric characters, dashes,
@@ -79,4 +85,4 @@ def upload_url(filename: str):
         raise HTTPException(status_code=400, detail="Invalid file extension")
 
     url = get_presigned_url(f"uploads/{filename}")
-    return {"url": url}
+    return UploadURLResponse(url=url)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class RootResponse(BaseModel):
+    status: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class SecureResponse(BaseModel):
+    user: str
+
+
+class UploadURLResponse(BaseModel):
+    url: str

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,22 +1,35 @@
+import os
+import sys
+
 from fastapi.testclient import TestClient
 
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from backend.main import app
+from backend.schemas import (
+    RootResponse,
+    SecureResponse,
+    TokenResponse,
+    UploadURLResponse,
+)
 
 client = TestClient(app)
 
 def test_root():
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    data = RootResponse.model_validate(response.json())
+    assert data.status == "ok"
 
 def test_token_auth_flow():
     response = client.post("/token", data={"username": "alice", "password": "secret"})
     assert response.status_code == 200
-    token = response.json()["access_token"]
+    token = TokenResponse.model_validate(response.json()).access_token
 
     secure = client.get("/secure", headers={"Authorization": f"Bearer {token}"})
     assert secure.status_code == 200
-    assert secure.json() == {"user": "alice"}
+    user_data = SecureResponse.model_validate(secure.json())
+    assert user_data.user == "alice"
 
 
 def test_upload_url_valid_filename(monkeypatch):
@@ -25,7 +38,8 @@ def test_upload_url_valid_filename(monkeypatch):
     )
     response = client.get("/upload-url", params={"filename": "good.txt"})
     assert response.status_code == 200
-    assert response.json()["url"] == "http://example.com/upload"
+    upload_data = UploadURLResponse.model_validate(response.json())
+    assert upload_data.url == "http://example.com/upload"
 
 
 def test_upload_url_invalid_filename():


### PR DESCRIPTION
## Summary
- Introduce Pydantic response models for root, token, secure, and upload URL endpoints
- Annotate API endpoints with these models for automatic schema generation
- Adjust tests to parse responses using the new models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e15a5858832b89cf3297fcaedf7a