### PR TITLE
Ensure Document model is registered during DB initialization

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -15,6 +15,7 @@ def init_db() -> None:
     if engine.url.get_backend_name().startswith("postgresql"):
         with engine.begin() as conn:
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    from . import models  # noqa: F401
     Base.metadata.create_all(bind=engine)
 
 def get_db():


### PR DESCRIPTION
## Summary
- import backend models before calling `Base.metadata.create_all`

## Testing
- `uvicorn backend.main:app` (timeout) && `sqlite3 app.db ".tables"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e5fe0730832bbb1fd4c8b639f8c7