### PR TITLE
Require SECRET_KEY and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ cd backend
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+export SECRET_KEY="your-secret-key"
 uvicorn main:app --reload
 ```
+
+The backend requires a `SECRET_KEY` environment variable for signing JWTs. Set this to a strong, random value in your deployment environment. Livy will raise a `RuntimeError` if `SECRET_KEY` is not defined.
 
 ---
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -6,7 +6,9 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 
-SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable is not set")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,8 +2,11 @@
 import os
 import sys
 
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
 from fastapi.testclient import TestClient
 from passlib.hash import bcrypt
+import pytest
 
 # Make "backend" importable when running `pytest` from repo root
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -58,3 +61,12 @@ def test_upload_url_valid_filename(monkeypatch):
 def test_upload_url_invalid_filename():
     resp = client.get("/upload-url", params={"filename": "../bad.txt"})
     assert resp.status_code == 400
+
+
+def test_missing_secret_key(monkeypatch):
+    import importlib
+    import backend.auth as auth
+
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        importlib.reload(auth)


### PR DESCRIPTION
## Summary
- ensure a runtime error is raised if `SECRET_KEY` is missing
- document `SECRET_KEY` environment variable requirement in README
- update tests for the new requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e633de80832b94189c53d59be7ba