### PR TITLE
Make CORS settings configurable via environment variables

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,11 +24,17 @@ from .schemas import (
 
 app = FastAPI(title="Livy Backend")
 
+# Read CORS settings from environment variables with sensible defaults
+_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
+allow_origins = [origin.strip() for origin in _origins.split(",") if origin.strip()]
+allow_credentials = os.getenv("ALLOW_CREDENTIALS", "false").lower() == "true"
+allow_methods = [m.strip() for m in os.getenv("ALLOW_METHODS", "*").split(",") if m.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://example.com"],
-    allow_credentials=False,
-    allow_methods=["*"],
+    allow_origins=allow_origins,
+    allow_credentials=allow_credentials,
+    allow_methods=allow_methods,
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Summary
- configure CORS middleware from `ALLOWED_ORIGINS`, `ALLOW_CREDENTIALS`, and `ALLOW_METHODS` environment variables
- default to `http://localhost:3000` when origins are not set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898eb092cb4832b83e7708fd19e3b7c